### PR TITLE
Upgrade connections to secure https

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ We use [Wordnik's](https://www.wordnik.com/) API to get random words and generat
 
 Simple click generate and you won't have to think about variable names ever again.
 
-### Go to the [website](http://soyzamudio.github.io/variable-randomizer) now!
+### Go to the [website](https://soyzamudio.github.io/variable-randomizer) now!

--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@
   <link rel="stylesheet" href="css/main.css">
   <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="bower_components/ionicons/css/ionicons.min.css">
-  <link href='http://fonts.googleapis.com/css?family=Source+Code+Pro' rel='stylesheet' type='text/css'>
-  <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,500,600,700' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Source+Code+Pro' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,500,600,700' rel='stylesheet' type='text/css'>
   <script src="bower_components/angular/angular.min.js"></script>
 </head>
 <body ng-cloak ng-controller='HomeController'>

--- a/js/service.js
+++ b/js/service.js
@@ -2,7 +2,7 @@ angular.module('Variables')
 .factory('Words', ['$http', function($http) {
 
   function getWords(number) {
-    return $http.get('http://api.wordnik.com:80/v4/words.json/randomWords?hasDictionaryDef=false&minCorpusCount=0&maxCorpusCount=-1&minDictionaryCount=1&maxDictionaryCount=-1&minLength=2&maxLength=7&limit=' + number + '&api_key=a2a73e7b926c924fad7001ca3111acd55af2ffabf50eb4ae5');
+    return $http.get('https://api.wordnik.com/v4/words.json/randomWords?hasDictionaryDef=false&minCorpusCount=0&maxCorpusCount=-1&minDictionaryCount=1&maxDictionaryCount=-1&minLength=2&maxLength=7&limit=' + number + '&api_key=a2a73e7b926c924fad7001ca3111acd55af2ffabf50eb4ae5');
   }
 
   return {getWords:getWords};


### PR DESCRIPTION
Fix not working  secured https variant of website: https://soyzamudio.github.io/variable-randomizer/

This variant is enforced for users with browser extenstion "[HTTPS everywhere](https://www.eff.org/https-everywhere)".

Because GitHub is preparing switch all own projects to https only, is good time to do that.
